### PR TITLE
remove extraneous argument to use_ok

### DIFF
--- a/t/00-load.t
+++ b/t/00-load.t
@@ -4,4 +4,4 @@ use strict;
 use warnings;
 
 use Test::More tests => 1;
-use_ok( 'File::Dedup', 'able to import module File::Dedup' ); 
+use_ok( 'File::Dedup' );


### PR DESCRIPTION
use_ok does not accept a test name, but passes its extra arguments to the module's import method. Perl has always ignored these extraneous arguments, but future versions are intending to make it an error to pass arguments to an undefined import method.